### PR TITLE
add Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
+gem 'rest-client'
+gem 'json'
+
+# Only required for file upload types (Guardium and Qualys to Kenna Direct), comment out if unneeded:
+gem 'nokogiri'


### PR DESCRIPTION
Add a gemfile to ease installation of required libraries with bundler. If bundler is not used, this should work using system gems as before. This Gemfile also serves as documentation of the needed libraries that are outside the standard library.
